### PR TITLE
allow meteor_runtime_config properties in settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You can pass an additional settings file using the `--settings` or `-s` option:
 
     $ meteor-build-client ../myOutputFolder -s ../settings.json
 
-**Note** Only the `public` property of that JSON file will be add to the `Meteor.settings` property.
+**Note**  The only properties in this file that will be processed are:
+- The `public` property of that JSON file will be added to the `Meteor.settings` property.
+- The `meteor_runtime_config` property of that JSON file will be added to the generated `__METEOR_RUNTIME_CONFIG__` options.
 
 
 ### App URL

--- a/meteor.js
+++ b/meteor.js
@@ -144,6 +144,7 @@ module.exports = {
         '        <script type="text/javascript" src="'+ files['js'] +'"></script>'+ "\n";
 
         // add the meteor runtime config
+
         settings = {
             'meteorRelease': starJson.meteorRelease,
             'ROOT_URL_PATH_PREFIX': '',
@@ -161,8 +162,11 @@ module.exports = {
         if(settingsJson.public)
             settings.PUBLIC_SETTINGS = settingsJson.public;
 
+        if(settingsJson.meteor_runtime_config)
+            settings = _.extend(settings, settingsJson.meteor_runtime_config);
+
         scripts = scripts.replace('__meteor_runtime_config__', '<script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent("'+encodeURIComponent(JSON.stringify(settings))+'"));</script>');
-        
+
         // add Meteor.disconnect() when no server is given
         if(!program.url)
             scripts += '        <script type="text/javascript">Meteor.disconnect();</script>';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-build-client",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A bundles the client part of a Meteor app.",
   "author": "Fabian Vogelsteller <fabian@frozeman.de>",
   "contributors": [


### PR DESCRIPTION
Per issue: https://github.com/frozeman/meteor-build-client/issues/25

Hope this is helpful... it doesn't hardcode the new meteorEnv setting, rather it expands the settings.json file to let me pass my own meteor_runtime_config options as needed. Once meteor 1.3 hits you'll probably want to hardcode the new setting for everyone.
