### PR TITLE
Provide a default encoding in case no {{>head}} is found

### DIFF
--- a/meteor.js
+++ b/meteor.js
@@ -103,7 +103,7 @@ module.exports = {
             try{
                 head = fs.readFileSync(path.join(buildPath, 'head.html'), {encoding: 'utf8'});
             } catch(e) {
-                head = '';
+                head = '<meta charset="utf-8" /> '; // provide default encoding
                 console.log('No <head> found in Meteor app...');
             }
             // ADD HEAD


### PR DESCRIPTION
If users choose the total default without any custom <head> tags a default encoding should still be set in order to support proper font encoding for the most languages.